### PR TITLE
fix ios7 bug when getting cell view from superview

### DIFF
--- a/Classes/BDDynamicGridViewController.m
+++ b/Classes/BDDynamicGridViewController.m
@@ -379,8 +379,9 @@
 
 - (void)gesture:(UIGestureRecognizer*)gesture view:(UIView**)view viewIndex:(NSInteger*)viewIndex
 {
-        
-    BDDynamicGridCell *cell = (BDDynamicGridCell*) [gesture.view.superview superview];
+    UIView *v = gesture.view;
+    while (v && ![v isKindOfClass:[BDDynamicGridCell class]]) v = v.superview;
+    BDDynamicGridCell *cell = (BDDynamicGridCell *) v;
     
     CGPoint locationInGridContainer = [gesture locationInView:gesture.view];    
     for (int i=0; i < cell.gridContainerView.subviews.count; i++){


### PR DESCRIPTION
when gesture:view:viewIndex: message try to retrieve the table cell
object from the superview it crash, because there's a new view inside
the table cell view hierarchy, look here:
http://www.curiousfind.com/blog/date/2013/09.
