### PR TITLE
Fix tableview is now added to bottom of view stack

### DIFF
--- a/Classes/BDDynamicGridViewController.m
+++ b/Classes/BDDynamicGridViewController.m
@@ -73,7 +73,7 @@
     _tableView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     self.borderWidth = kDefaultBorderWidth;
     self.view.frame =  CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height);
-    [self.view addSubview:_tableView];
+    [self.view insertSubview:_tableView atIndex:0];
     _tableView.frame = self.view.bounds;
     [self reloadData];
     


### PR DESCRIPTION
This fix addresses an issue where controls dragged onto a view controller in the storyboard would not be visible.

This is because the tableview was added to the top of the view stack.
