### PR TITLE
Added ability to define number of views per cell

### DIFF
--- a/Classes/BDDynamicGridViewController.m
+++ b/Classes/BDDynamicGridViewController.m
@@ -166,14 +166,23 @@
         NSAssert(kMinViewsPerCell <= kMaxViewsPerCell, @"Minimum number of views per row cannot be greater than maximum number of views per row.");
         
         while (accumNumOfViews < self.delegate.numberOfViews) {
-            NSUInteger numOfViews = (arc4random() % kMaxViewsPerCell) + kMinViewsPerCell;
-            if (numOfViews > kMaxViewsPerCell) {
-                numOfViews = kMaxViewsPerCell;
-            }
-            numOfViews = (accumNumOfViews+numOfViews <= self.delegate.numberOfViews)?numOfViews:(self.delegate.numberOfViews-accumNumOfViews);
+            NSUInteger numOfViews = 0;
+
             ri = [BDRowInfo new];
             ri.order = _rowInfos.count;
             ri.accumulatedViews = accumNumOfViews;
+
+            if ([self.delegate respondsToSelector:@selector(numberOfViewsPerCell:)]) {
+                numOfViews = [self.delegate numberOfViewsPerCell:ri];
+            } else {
+                numOfViews = (arc4random() % kMaxViewsPerCell) + kMinViewsPerCell;
+
+                if (numOfViews > kMaxViewsPerCell) {
+                    numOfViews = kMaxViewsPerCell;
+                }
+                numOfViews = (accumNumOfViews+numOfViews <= self.delegate.numberOfViews)?numOfViews:(self.delegate.numberOfViews-accumNumOfViews);
+            }
+
             ri.viewsPerCell = numOfViews;
             accumNumOfViews = accumNumOfViews + numOfViews;
             _rowInfos = [_rowInfos arrayByAddingObject:ri];

--- a/Classes/BDDynamicGridViewDelegate.h
+++ b/Classes/BDDynamicGridViewDelegate.h
@@ -111,6 +111,11 @@
  */
 - (void) gridViewDidEndScrolling;
 
+/**
+ This method is called to determine the number of views in a cell.
+ @param rowInfo the row being calculated.
+ */
+- (NSUInteger)numberOfViewsPerCell:(BDRowInfo*)rowInfo;
 
 /**
  This method is called to determine the height of the specified row.


### PR DESCRIPTION
I've added support to define the number of views per cell, without specifying a custom layout.

In my use case, I did not want the "randomness" of the default layout. I needed to specify the exact number of views in a cell and there was no way to do this.

What do you think?
